### PR TITLE
fitscollectlc - a fitscollect-style tool to list light curve files in the camk file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,65 @@ examples:
 ```
 
 
+### fitscollectlc
+Collects OCA light curve files per target and/or observation programme.
+Returns paths to `*_light_curve.txt` files for selected targets, telescopes and filters.
+
+```bash
+(.venv) ~/projects/astro/ocascripts
+fitscollectlc --help
+usage: fitscollectlc [-h] [-o TARGET] [-t TEL] [-f FILTER] [-P SCIPROG] [-n] [-A ANALYTIC_DIR] [-D DIR] [-v]
+
+Collects OCA light curve files per target and/or observation programme.
+
+Returns paths to *_light_curve.txt files for selected targets, telescopes and filters.
+
+Light curve files are located at:
+    {telescope}/processed-ofp/targets/{target}/{filter}/light-curve/*_light_curve.txt
+
+When --sciprog is used, the list of targets is derived from the parquet report files
+in the analytic directory (same as fitscollectparquet).
+
+filtering options:
+  -o TARGET, --object TARGET
+                        Target name (directory name under targets/)
+  -t TEL, --telescope TEL
+                        Telescope name
+  -f FILTER, --filter FILTER
+                        Filter name
+  -P SCIPROG, --sciprog SCIPROG
+                        Science programme name (glob-style, repeatable).
+                        Derives target list from parquet report files.
+
+output format:
+  -n, --name            Print filenames only instead of full paths
+
+general options:
+  -A ANALYTIC_DIR, --analytic-dir ANALYTIC_DIR
+                        Analytic dir with parquet files (default: autodetect)
+  -D DIR, --dir DIR     Root FITS dir (default: autodetect)
+  -v, --verbose
+
+examples:
+
+    All light curves for target ux_car:
+        fitscollectlc -o ux_car
+
+    Light curves in B filter for all targets on telescope wk06:
+        fitscollectlc -t wk06 -f B
+
+    All light curves for targets in a science programme:
+        fitscollectlc -P FT2025B-1
+
+    Light curves in V filter for targets in a science programme:
+        fitscollectlc -P FT2025B-1 -f V
+
+    Filenames only:
+        fitscollectlc -o ux_car -n
+```
+
+Requires `pandas` and `pyarrow` when using `--sciprog`.
+
 ### fitscollectdownloader
 Generates a self-contained shell downloader script from a file list.
 Takes FITS filenames from stdin or arguments, requires OCADB username.

--- a/ocascripts/fitscollectlc.py
+++ b/ocascripts/fitscollectlc.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from argparse import ArgumentParser, Namespace
 from typing import Optional
 
+import pandas as pd
 from ocafitsfiles import detect_fits_root
 
 log = logging.getLogger('collectlc')
@@ -42,11 +43,6 @@ def glob_patterns_to_fullmatch_regex(patterns: list[str]) -> str:
 
 def objects_from_parquet(analytic_dir: Path, sciprog_patterns: list[str], telescope: str) -> list[str]:
     """Return unique lowercase object names matching the given SCIPROG patterns."""
-    try:
-        import pandas as pd
-    except ImportError:
-        log.error('pandas is required for --sciprog: pip install pandas pyarrow')
-        return []
 
     if '*' not in telescope:
         parquet_files = [analytic_dir / f'{telescope}_report.parquet']

--- a/ocascripts/fitscollectlc.py
+++ b/ocascripts/fitscollectlc.py
@@ -1,0 +1,189 @@
+"""Collects OCA light curve files per target and/or observation programme.
+
+Returns paths to *_light_curve.txt files for selected targets, telescopes and filters.
+
+Light curve files are located at:
+    {telescope}/processed-ofp/targets/{target}/{filter}/light-curve/*_light_curve.txt
+
+When --sciprog is used, the list of targets is derived from the parquet report files
+in the analytic directory (same as fitscollectparquet).
+
+v. 1.0.0
+"""
+import argparse
+import logging
+import re
+import signal
+import sys
+from pathlib import Path
+from argparse import ArgumentParser, Namespace
+from typing import Optional
+
+from ocafitsfiles import detect_fits_root
+
+log = logging.getLogger('collectlc')
+
+ANALYTIC_PROPOSITIONS = [
+    Path('/work/vela/oca/analytic'),
+]
+
+
+def detect_analytic_dir() -> Optional[Path]:
+    for p in ANALYTIC_PROPOSITIONS:
+        if p.is_dir():
+            return p
+    return None
+
+
+def glob_patterns_to_fullmatch_regex(patterns: list[str]) -> str:
+    """Convert simple glob patterns to a safe OR-regex for str.fullmatch."""
+    return '|'.join(re.escape(p).replace(r'\*', '.*') for p in patterns)
+
+
+def objects_from_parquet(analytic_dir: Path, sciprog_patterns: list[str], telescope: str) -> list[str]:
+    """Return unique lowercase object names matching the given SCIPROG patterns."""
+    try:
+        import pandas as pd
+    except ImportError:
+        log.error('pandas is required for --sciprog: pip install pandas pyarrow')
+        return []
+
+    if '*' not in telescope:
+        parquet_files = [analytic_dir / f'{telescope}_report.parquet']
+    else:
+        parquet_files = sorted(analytic_dir.glob('*_report.parquet'))
+
+    dfs = []
+    for pf in parquet_files:
+        if not pf.exists():
+            log.warning(f'Parquet file not found: {pf}')
+            continue
+        log.info(f'Loading {pf}')
+        try:
+            dfs.append(pd.read_parquet(pf, columns=['OBJECT', 'SCIPROG']))
+        except Exception as e:
+            log.warning(f'Cannot read {pf}: {e}')
+
+    if not dfs:
+        log.error(f'No parquet files loaded from {analytic_dir}')
+        return []
+
+    df = pd.concat(dfs, ignore_index=True) if len(dfs) > 1 else dfs[0]
+
+    pattern = glob_patterns_to_fullmatch_regex(sciprog_patterns)
+    df = df[df['SCIPROG'].str.fullmatch(pattern, case=False, na=False)]
+
+    objects = sorted({o.lower() for o in df['OBJECT'].dropna().unique()})
+    log.info(f'Found {len(objects)} unique objects for SCIPROG {sciprog_patterns}')
+    return objects
+
+
+def main() -> int:
+    argparser = ArgumentParser(description=__doc__,
+                               formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    filter_group = argparser.add_argument_group('filtering options', 'Criteria for selecting light curve files')
+    filter_group.add_argument('-o', '--object', help='Target name (directory name under targets/)', metavar='TARGET', default=None)
+    filter_group.add_argument('-t', '--telescope', help='Telescope name', metavar='TEL', default='*')
+    filter_group.add_argument('-f', '--filter', help='Filter name', default='*')
+    filter_group.add_argument('-P', '--sciprog', action='append', metavar='SCIPROG',
+                              help='Science programme name (glob-style, repeatable). '
+                                   'Derives target list from parquet report files.')
+
+    format_group = argparser.add_argument_group('output format')
+    format_group.add_argument('-n', '--name', help='Print filenames only instead of full paths', action='store_true')
+
+    general_group = argparser.add_argument_group('general options')
+    general_group.add_argument('-A', '--analytic-dir', help='Analytic dir with parquet files (default: autodetect)', default=None)
+    general_group.add_argument('-D', '--dir', help='Root FITS dir (default: autodetect)', default=None)
+    general_group.add_argument('-v', '--verbose', action='count', default=0)
+
+    argparser.epilog = """
+examples:
+
+    All light curves for target ux_car:
+        fitscollectlc -o ux_car
+
+    Light curves in B filter for all targets on telescope wk06:
+        fitscollectlc -t wk06 -f B
+
+    All light curves for targets in a science programme:
+        fitscollectlc -P FT2025B-1
+
+    Light curves in V filter for targets in a science programme:
+        fitscollectlc -P FT2025B-1 -f V
+
+    Filenames only:
+        fitscollectlc -o ux_car -n
+    """
+
+    args: Namespace = argparser.parse_args()
+
+    try:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    except (AttributeError, ValueError):
+        pass
+
+    log_format = '%(asctime)s [%(levelname)s] [%(name)s] %(message)s'
+    if args.verbose == 1:
+        logging.basicConfig(level=logging.INFO, format=log_format)
+    elif args.verbose > 1:
+        logging.basicConfig(level=logging.DEBUG, format=log_format)
+    else:
+        logging.basicConfig(level=logging.WARNING, format=log_format)
+
+    if args.dir is not None:
+        root_path = Path(args.dir)
+        if not root_path.is_dir():
+            log.error(f'Root FITS dir {root_path} not found')
+            return -1
+    else:
+        schema, root_path = detect_fits_root()
+        if root_path is None:
+            log.error('No root FITS dir found. Autodetect failed. Please specify with --dir.')
+            return -1
+        log.info(f'Autodetect schema {schema}, root FITS dir: {root_path}')
+
+    # Determine object pattern(s) to glob
+    if args.sciprog:
+        analytic_dir = Path(args.analytic_dir) if args.analytic_dir else detect_analytic_dir()
+        if not analytic_dir:
+            log.error('Cannot find analytic dir. Use -A to specify.')
+            return -1
+        objects = objects_from_parquet(analytic_dir, args.sciprog, args.telescope)
+        if not objects:
+            log.warning('No objects found for the given --sciprog filter')
+            return 0
+        if args.object:
+            obj_re = re.compile(glob_patterns_to_fullmatch_regex([args.object.lower()]))
+            objects = [o for o in objects if obj_re.fullmatch(o)]
+        object_patterns = objects
+    else:
+        object_patterns = [args.object.lower() if args.object else '*']
+
+    log.debug(f'Object patterns ({len(object_patterns)}): {object_patterns}')
+    log.debug(f'Telescope: {args.telescope}')
+    log.debug(f'Filter: {args.filter}')
+
+    count = 0
+    for obj in object_patterns:
+        glob_pattern = (f'{args.telescope}/processed-ofp/targets/{obj}/{args.filter}'
+                        f'/light-curve/*_light_curve.txt')
+        log.debug(f'Glob: {glob_pattern}')
+        for path in sorted(root_path.glob(glob_pattern)):
+            print(path.name if args.name else path)
+            count += 1
+
+    log.info(f'Light curve files found: {count}')
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        ret_code = main()
+        exit(ret_code)
+    except BrokenPipeError:
+        try:
+            sys.stdout.close()
+        finally:
+            exit(0)

--- a/ocascripts/fitscollectlc.py
+++ b/ocascripts/fitscollectlc.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from argparse import ArgumentParser, Namespace
 from typing import Optional
 
-import pandas as pd
 from ocafitsfiles import detect_fits_root
 
 log = logging.getLogger('collectlc')
@@ -43,6 +42,7 @@ def glob_patterns_to_fullmatch_regex(patterns: list[str]) -> str:
 
 def objects_from_parquet(analytic_dir: Path, sciprog_patterns: list[str], telescope: str) -> list[str]:
     """Return unique lowercase object names matching the given SCIPROG patterns."""
+    import pandas as pd
 
     if '*' not in telescope:
         parquet_files = [analytic_dir / f'{telescope}_report.parquet']
@@ -142,6 +142,11 @@ examples:
 
     # Determine object pattern(s) to glob
     if args.sciprog:
+        try:
+            import pandas  # noqa: F401
+        except ImportError:
+            log.error('pandas is required for --sciprog: pip install pandas pyarrow')
+            return 1
         analytic_dir = Path(args.analytic_dir) if args.analytic_dir else detect_analytic_dir()
         if not analytic_dir:
             log.error('Cannot find analytic dir. Use -A to specify.')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,16 @@ python = "^3.10"
 requests = "^2.32.5"
 ocafitsfiles = {git = "https://github.com/araucaria-project/ocafitsfiles.git"}
 
+[tool.poetry.extras]
+parquet = ["pandas", "pyarrow"]
+
 [tool.poetry.dependencies.pandas]
 version = ">=1.5"
+optional = true
 
 [tool.poetry.dependencies.pyarrow]
 version = ">=10.0"
+optional = true
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,11 @@ python = "^3.10"
 requests = "^2.32.5"
 ocafitsfiles = {git = "https://github.com/araucaria-project/ocafitsfiles.git"}
 
-[tool.poetry.extras]
-parquet = ["pandas", "pyarrow"]
-
 [tool.poetry.dependencies.pandas]
 version = ">=1.5"
-optional = true
 
 [tool.poetry.dependencies.pyarrow]
 version = ">=10.0"
-optional = true
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ pytest = "^8.3.5"
 
 [tool.poetry.scripts]
 fitscollect = "ocascripts.fitscollect:main"
+fitscollectlc = "ocascripts.fitscollectlc:main"
 fitscollectcalib = "ocascripts.fitscollectcalib:main"
 fitscollectjson = "ocascripts.fitscollectjson:main"
 fitscollectlist = "ocascripts.fitscollectlist:main"

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -48,3 +48,13 @@ def test_fitscollectjson_help():
     assert result.returncode == 0
     assert 'json' in result.stdout.lower()
 
+
+def test_fitscollectlc_help():
+    result = subprocess.run(
+        ['python3', '-m', 'ocascripts.fitscollectlc', '--help'],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert 'light curve' in result.stdout.lower()
+

--- a/tests/test_fitscollectlc_objects_from_parquet.py
+++ b/tests/test_fitscollectlc_objects_from_parquet.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Tests for objects_from_parquet SCIPROG filtering in fitscollectlc."""
+
+import pytest
+
+pd = pytest.importorskip('pandas')
+pytest.importorskip('pyarrow')
+
+from ocascripts.fitscollectlc import objects_from_parquet
+
+
+@pytest.fixture
+def analytic_dir(tmp_path):
+    df = pd.DataFrame({
+        'OBJECT': ['UX_Car', 'ss_for', 'RR_Lyr', 'SX_For', None],
+        'SCIPROG': ['FT2025B-1', 'FT2025B-1', 'FT2025A-9', 'FT2025B-1', 'FT2025B-1'],
+    })
+    df.to_parquet(tmp_path / 'wk06_report.parquet')
+    return tmp_path
+
+
+def test_filters_by_sciprog_and_lowercases_objects(analytic_dir):
+    objects = objects_from_parquet(analytic_dir, ['FT2025B-1'], '*')
+    assert objects == ['ss_for', 'sx_for', 'ux_car']
+
+
+def test_sciprog_glob_pattern(analytic_dir):
+    objects = objects_from_parquet(analytic_dir, ['FT2025*'], '*')
+    assert objects == ['rr_lyr', 'ss_for', 'sx_for', 'ux_car']
+
+
+def test_no_matching_sciprog_returns_empty(analytic_dir):
+    assert objects_from_parquet(analytic_dir, ['NO-MATCH'], '*') == []
+
+
+def test_specific_telescope_uses_matching_parquet_file(analytic_dir, tmp_path):
+    other = pd.DataFrame({'OBJECT': ['OTHER_OBJ'], 'SCIPROG': ['FT2025B-1']})
+    other.to_parquet(tmp_path / 'wk05_report.parquet')
+
+    objects = objects_from_parquet(analytic_dir, ['FT2025B-1'], 'wk06')
+    assert 'other_obj' not in objects
+    assert objects == ['ss_for', 'sx_for', 'ux_car']


### PR DESCRIPTION
A tool to list light curve txt files for given sciprog, objects, telescopes and filters. It navigates the directory structure to filter by telescope, object and filter and uses the analytic file (similarly to fitscollectparquet) to get info about objects belonging to a given SCIPROG. Then uses the objects to reach the right target directories.
It follows the convention of the fitscollect family of tools.